### PR TITLE
DELCARE SHOT DEAD IN THE BRONX

### DIFF
--- a/Content/Blueprints/UI/Widgets/GameMenu/Levers/WBP_SingleDecree.uasset
+++ b/Content/Blueprints/UI/Widgets/GameMenu/Levers/WBP_SingleDecree.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7ec2bdfc8207143a86f5ebe1fd2f293325426a41044f658bc8dff60f760f8ba7
-size 1984155
+oid sha256:cfee8b2c1f19c9e276ef5b8e278e57f61cf87744dde418ec5f3b6c41455394ba
+size 1982219


### PR DESCRIPTION
Changed WBP_SingleDecree to no longer have the evil (insurance company?) DELCARE featured in our SILLY game full of SILLY WHIMSY. No corpo sh**!!!!!

To Test: Please check if the confirmation button a decree card says "Declare" or the evil "Delcare". It should say "Declare".